### PR TITLE
Fix NamedItemList index bounds checks

### DIFF
--- a/odxtools/nameditemlist.py
+++ b/odxtools/nameditemlist.py
@@ -65,7 +65,7 @@ class NamedItemList(Generic[T]):
 
     def __getitem__(self, key: Union[int, str, slice]) -> T:
         if isinstance(key, int):
-            if abs(key) < -len(self._list) or key >= len(self._list):
+            if key < -len(self._list) or key >= len(self._list):
                 # we want to raise a KeyError instead of an IndexError
                 # if the index is out of range...
                 raise KeyError(f"Tried to access item {key} of a NamedItemList "
@@ -86,7 +86,7 @@ class NamedItemList(Generic[T]):
         -> Optional[T]:
 
         if isinstance(key, int):
-            if abs(key) < -len(self._list) or key >= len(self._list):
+            if key < -len(self._list) or key >= len(self._list):
                 return None
 
             return self._list[key]


### PR DESCRIPTION
## Summary
- fix index range checks for negative indices in `NamedItemList`

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'bitstruct')*

------
https://chatgpt.com/codex/tasks/task_b_6840be718894832bbe0171b46019cb39