### PR TITLE
SW-22938: relax the python-can bound from <= 4.2 to >= 4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires_list = [
     "argparse_addons",
     "PyInquirer",
     "jinja2",
-    "python-can <= 4.2",
+    "python-can >= 4.2",
     "can-isotp",
     "markdownify",
     "deprecation",


### PR DESCRIPTION
One line in `setup.py`:

```diff
-    "python-can <= 4.2",
+    "python-can >= 4.2",
```

## Why

The upper bound blocks the backend monorepo from moving python-can off 4.2.0, which is
what SW-22938 needs in order to clear two advisories:

- `PYSEC-2026-3625` — `msgpack` 1.0.8. python-can 4.2.0 declares `msgpack~=1.0.0`; the fix
  is 1.2.1, permanently outside that range. 4.6.1 moves `msgpack` to the `multicast` extra,
  so it leaves the dependency graph entirely.
- `PYSEC-2026-3447` — `setuptools` 80.10.2. python-can 4.2.0 still does
  `from pkg_resources import iter_entry_points`, so the workspace has to pin
  `setuptools<81`. 4.6.1 has no `setuptools` dependency at all.

With the cap in place `uv lock` fails outright:

```
Because only odxtools==3.0.1 is available and odxtools==3.0.1 depends on python-can<=4.2,
we can conclude that all versions of odxtools depend on python-can<=4.2.
```

## Why the cap is safe to lift

- Upstream `mercedes-benz/odxtools` has itself relaxed this to `python-can >= 4.2`, so the
  `<=` is stale rather than a deliberate ceiling.
- odxtools touches exactly one python-can API: `can.Message(arbitration_id=...)` in
  `odxtools/isotp_state_machine.py`. That constructor is unchanged in 4.6.1.
- Nothing in the backend monorepo imports isotp at all, so the coupling is inert there.

## Verified

Against python-can 4.6.1 in the backend uv workspace: odxtools imports cleanly, and both
consumers pass — `odxtoolsapi` 48 tests, `odxprocessor` 355 tests.

## Note for whoever merges

`sovd-openapi/pyproject.toml:26` carries a PEP 508 direct reference to this repo at the old
revision `42c3674f`, so backend needs a `override-dependencies` entry until sovd-openapi
bumps its own reference. That bump is tracked separately; merging this is the prerequisite.

Refs: SW-22938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gez8YexAaseR8EJJULAEwU