### PR TITLE
SW-21904: resolve TABLE-KEY table via TABLE-ROW-REF

### DIFF
--- a/odxtools/parameters/tablekeyparameter.py
+++ b/odxtools/parameters/tablekeyparameter.py
@@ -57,8 +57,14 @@ class TableKeyParameter(Parameter):
         if self.table_ref:
             self.table = odxlinks.resolve(self.table_ref)
 
+        self.table_row = None
         if self.table_row_ref:
             self.table_row = odxlinks.resolve(self.table_row_ref)
+            if self.table is None and self.table_row.table_ref is not None:
+                # Do not use `self.table_row.table` here: the order of
+                # reference resolution is undefined, so the table may not
+                # have resolved its own references yet.
+                self.table = odxlinks.resolve(self.table_row.table_ref)
         if self.table_row_snref:
             self.table_row = parent_dl.local_diag_data_dictionary_spec.tables[self.table_row_snref]
 

--- a/odxtools/table.py
+++ b/odxtools/table.py
@@ -50,13 +50,15 @@ class TableRow:
     description: Optional[str]
     semantic: Optional[str]
     sdgs: List[SpecialDataGroup]
+    table_ref: Optional[OdxLinkRef] = None
 
     def __post_init__(self) -> None:
         self._structure: Optional[DopBase] = None
         self._dop: Optional[DopBase] = None
 
     @staticmethod
-    def from_et(et_element, doc_frags: List[OdxDocFragment]) \
+    def from_et(et_element, doc_frags: List[OdxDocFragment],
+                table_ref: Optional[OdxLinkRef] = None) \
             -> "TableRow":
         """Reads a TABLE-ROW."""
         odx_id=OdxLinkId.from_et(et_element, doc_frags)
@@ -85,6 +87,7 @@ class TableRow:
             structure_ref=structure_ref,
             dop_ref=dop_ref,
             sdgs=sdgs,
+            table_ref=table_ref,
         )
 
     def _build_odxlinks(self) -> Dict[OdxLinkId, Any]:
@@ -173,7 +176,7 @@ class Table(TableBase):
         logger.debug("Parsing TABLE " + short_name)
 
         table_rows = [
-            TableRow.from_et(tr_elem, doc_frags)
+            TableRow.from_et(tr_elem, doc_frags, table_ref=OdxLinkRef.from_id(odx_id))
             for tr_elem in et_element.iterfind("TABLE-ROW")
         ]
 

--- a/tests/test_table_key_parameter.py
+++ b/tests/test_table_key_parameter.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+import unittest
+from xml.etree import ElementTree
+
+from odxtools.odxlink import OdxDocFragment, OdxLinkDatabase
+from odxtools.parameters.createanyparameter import create_any_parameter_from_et
+from odxtools.table import Table
+
+# the document fragment which is used throughout the test
+doc_frags = [OdxDocFragment("UnitTest", "unit_test_doc")]
+
+TABLE_XML = """
+<TABLE ID="table.flip_quality">
+  <SHORT-NAME>flip_quality</SHORT-NAME>
+  <TABLE-ROW ID="table.flip_quality.best">
+    <SHORT-NAME>best</SHORT-NAME>
+    <KEY>10</KEY>
+  </TABLE-ROW>
+</TABLE>
+"""
+
+# a TABLE-KEY which pins one row via TABLE-ROW-REF and hence names
+# neither TABLE-REF nor TABLE-SNREF
+TABLE_KEY_XML = """
+<PARAM xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       ID="param.flip_quality_key" xsi:type="TABLE-KEY">
+  <SHORT-NAME>flip_quality_key</SHORT-NAME>
+  <TABLE-ROW-REF ID-REF="table.flip_quality.best"/>
+</PARAM>
+"""
+
+
+class TestTableKeyParameter(unittest.TestCase):
+
+    def test_table_resolved_from_table_row_ref(self):
+        table = Table.from_et(ElementTree.fromstring(TABLE_XML), doc_frags)
+        param = create_any_parameter_from_et(ElementTree.fromstring(TABLE_KEY_XML), doc_frags)
+
+        odxlinks = OdxLinkDatabase()
+        # DiagDataDictionarySpec registers the table itself, Table only its rows
+        odxlinks.update({table.odx_id: table})
+        odxlinks.update(table._build_odxlinks())
+        odxlinks.update(param._build_odxlinks())
+
+        table._resolve_references(odxlinks)
+        param._resolve_references(None, odxlinks)
+
+        self.assertEqual(param.table, table)
+        self.assertEqual(param.table_row.short_name, "best")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

A `TABLE-KEY` parameter may pin a single row with `TABLE-ROW-REF` and name neither `TABLE-REF` nor `TABLE-SNREF`. This is valid ODX, but we only ever set `table` from the latter two, so such a parameter raises

```
ValueError: Either table_key_ref or table_key_snref must be defined.
```

That aborts the whole `load_pdx_file()`, so the caller gets zero ECUs rather than a partial result. Reported via [SW-21904](https://sibros.atlassian.net/browse/SW-21904), where a customer saw only 2 of their 5 ECUs in the "UDS Faults to Log" picker — the other PDX files failed to parse entirely.

Minimal repro from the affected file:

```xml
<PARAM SEMANTIC="ID" ID="BV.TGW24_C093.PR.PR_ActiveDiagnosticInformation_Read.PA.RecordDataIdentifier" xsi:type="TABLE-KEY">
  <SHORT-NAME>RecordDataIdentifier</SHORT-NAME>
  <TABLE-ROW-REF ID-REF="BV.TGW24_C093.TA.Identification_Read_PR.TR.ActiveDiagnosticInformation" />
</PARAM>
```

## Cause

`Table.from_et` discarded the XML's `TABLE` → `TABLE-ROW` containment. A parsed `TableRow` held no link back to its table, so resolving `TABLE-ROW-REF` was a dead end: you had the row, but it could not lead you to the table.

## Fix

- `TableRow` gains a `table_ref`, stamped by `Table.from_et` while it parses its own rows.
- `TableKeyParameter._resolve_references` follows it when no table is named directly: `TABLE-ROW-REF` → row → `row.table_ref` → table.

The second hop goes through `odxlinks` rather than a cached attribute because reference-resolution order is undefined — the `Table` may not have resolved its own references yet. `table_ref` is set at parse time, so it is always ready.

Also initialises `self.table_row = None`. That is not required by the fix; it patches a latent `AttributeError` for params that use `TABLE-REF` alone, where the attribute was previously never assigned.

## Upstream

Backport of `a6ced58`, `eb8ac39`, `b7db485` and `0576234` from mercedes-benz/odxtools, which fixed this across 4.1.0 → 11.1.0. Verified upstream 11.1.0 loads the affected PDX cleanly.

One deliberate deviation: upstream made `table_ref` a required field and updated every call site. Here it keeps a default, so the existing `TableRow(...)` constructions in `tests/` and `examples/somersaultecu.py` stay untouched.

## Testing

### odxtools

- New `tests/test_table_key_parameter.py`. Fails on `main` with the `ValueError`, passes with the fix.
- Full suite: `105 passed, 1 skipped` (was 104).
- `mypy` as CI runs it: 5 errors, identical to `main` — all pre-existing.

### The affected PDX

- Loads: 3 DLCs, both row-ref-only params resolve to `table Identification_Read_PR / row ActiveDiagnosticInformation`.
- Through odxprocessor it previously produced zero ECUs. Now every supported UDS service converts, 2 ECUs each — `0x10` (12 services), `0x11` (8), `0x14` (2), `0x19` (60), `0x22` (7), `0x27` (8), `0x28` (8), `0x2e` (5), `0x2f` (0), `0x31` (4), `0x85` (8). The formerly-fatal parameter now appears as a resolved `tableKey/tableRow`.
- Residual failures are pre-existing odxprocessor gaps unrelated to this change, and degrade individual parameters rather than aborting the file: 32x `NOT IMPLEMENTED YET - DiagCodedType: LeadingLengthInfoType` and 6x `coded-value for Security Access not defined for UnlockedL1`.

### Consumers — no observable change

Both downstream consumers were run with the pin repointed at this commit and compared against the current pinned rev (`42c3674`):

- **sovd-openapi golden suite**: `make regenerate-golden` (deletes and rewrites `tests/openapi` and `tests/static_endpoints`) — `74 passed`, all 17 goldens **byte-identical**. Nothing for a `CHANGELOG.md` entry to describe.
- **sovd-openapi ceer corpus** (56 PDX through `PDX().parse()` + `to_openapi()`): `ok=56 fail=0` on both revs, and the 56 generated specs are **byte-identical between the two revs**. None of these files were failing before, so none start succeeding — they contain no row-ref-only table keys.
- **odxprocessor golden suite** against this branch vs unpatched `main`: identical results (682 failed, 355 passed in a checkout with incomplete golden data) — **zero regressions, zero golden changes**. Same reason: no PDX in that corpus exercises row-ref-only table keys.

The affected PDX is the only input in any corpus we have that this fix changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

